### PR TITLE
Bot not appearing in correct langauge

### DIFF
--- a/karma.js
+++ b/karma.js
@@ -492,7 +492,7 @@ function createUserAndStartConversation(message, bot) {
     .then((profile) => {
       const region = regionByTimeZone(profile.timezone);
       services.createUser(message.user,
-                          config.rapidproGroups[[(region)]],
+                          [config.rapidproGroups[region]],
                           pickLanguage(profile),
                           profile,
                           {referrer: message.referral.ref})

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/onaio/karma#readme",
   "dependencies": {
-    "borq": "^0.0.1-alpha.15",
+    "borq": "^0.0.1-alpha.16",
     "eslint": "^4.4.1",
     "eslint-config-google": "^0.9.1",
     "express-winston": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -517,9 +517,9 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-borq@^0.0.1-alpha.15:
-  version "0.0.1-alpha.15"
-  resolved "https://registry.yarnpkg.com/borq/-/borq-0.0.1-alpha.15.tgz#6f143a435351743177c76f3dcb370a0971df3ae4"
+borq@^0.0.1-alpha.16:
+  version "0.0.1-alpha.16"
+  resolved "https://registry.yarnpkg.com/borq/-/borq-0.0.1-alpha.16.tgz#d93617f07a629ec529805b45081a7741d9c1d04e"
   dependencies:
     botkit "0.5.8"
     express-winston "^2.4.0"


### PR DESCRIPTION
To set the language check the user locale then timezone, if that fails
use the default language
Set the user's Rapidpro group based on timezone if not put them in a default Karma group.

Fixes #27 