### PR TITLE
Set the user as none if they don't have a referrer

### DIFF
--- a/karma.js
+++ b/karma.js
@@ -421,11 +421,13 @@ function createUserAndStartConversation(message, bot) {
   services.getFacebookProfile(message.user)
     .then((profile) => {
       const region = regionByTimeZone(profile.timezone);
+      const extraFields = message.referral ? {referrer: message.referral.ref} :
+            {referrer: 'none'};
       services.createUser(message.user,
                           [config.rapidproGroups[region]],
                           pickLanguage(profile),
                           profile,
-                          {referrer: message.referral.ref})
+                          extraFields)
         .then((rapidProContact) => {
           bot.startConversation(message, (err, convo) => {
             karmaConversation(err, convo, rapidProContact);


### PR DESCRIPTION
Lacking the referrer caused the bot not to create a user in Rapidpro. We want this user to be created with referrer set to "none" in such cases.

Closes #48