### PR TITLE
Call updateUser instead of updateRapidProContact

### DIFF
--- a/karma.js
+++ b/karma.js
@@ -358,7 +358,7 @@ function karmaConversation(err, convo, {uuid, name, language}) {
 function prepareConversation(bot, message, newLanguage) {
   const {user} = message;
   if (newLanguage) {
-    services.updateRapidProContact({urn: `facebook:${user}`},
+    services.updateUser({urn: `facebook:${user}`},
                                    {language: newLanguage})
       .then((rapidProContact) => {
         bot.startConversation(message, (err, convo) => {

--- a/setup.js
+++ b/setup.js
@@ -98,7 +98,7 @@ function setup (bot) {
           payload: 'switch_in',
         },
         {
-          title: 'Portuguese',
+          title: 'Português',
           type: 'postback',
          payload: 'switch_pt',
         },


### PR DESCRIPTION
Call `services.updateUser` instead of `services.updateRapidPro` contact

Fixes #67 
