### PR TITLE
Use conversations.utterances for yes/no validation

### DIFF
--- a/lib/conversations/one.js
+++ b/lib/conversations/one.js
@@ -6,7 +6,7 @@ const {
   logger,
   localeUtils,
   translate: t,
-  conversations: {nextConversation, goto},
+  conversations: {nextConversation, goto, utterances},
   facebookUtils: {generateQuickReply},
 } = require('borq');
 const {
@@ -69,11 +69,11 @@ function botOne(
     ]),
     [
       {
-        pattern: 'yes_with_someone',
+        pattern: utterances.yes,
         callback: goto('with whom name'),
       },
       {
-        pattern: 'no_with_someone',
+        pattern: utterances.no,
         callback: goto('skip yes'),
       },
       {
@@ -119,7 +119,7 @@ function botOne(
     ]),
     [
       {
-        pattern: 'yesWithSomeoneElse',
+        pattern: utterances.yes,
         callback: (_, conversation) => {
           conversation.responses.repeat.with_whom.push(
             repeatAnyoneObject(conversation)
@@ -129,7 +129,7 @@ function botOne(
         },
       },
       {
-        pattern: 'noWithSomeoneElse',
+        pattern: utterances.no,
         callback: (_, conversation) => {
           conversation.responses.repeat.with_whom.push(
             repeatAnyoneObject(conversation)

--- a/lib/conversations/three.js
+++ b/lib/conversations/three.js
@@ -4,7 +4,7 @@ const {
   logger,
   localeUtils,
   translate: t,
-  conversations: {goto},
+  conversations: {goto, utterances},
   facebookUtils: {generateQuickReply},
 } = require('borq');
 
@@ -92,11 +92,11 @@ function botThree(
     ]),
     [
       {
-        pattern: 'yes_concern',
+        pattern: utterances.yes,
         callback: goto('who did you talk to'),
       },
       {
-        pattern: 'no_concern',
+        pattern: utterances.no,
         callback: goto('graceful ending'),
       },
       {
@@ -177,7 +177,7 @@ function botThree(
     ]),
     [
       {
-        pattern: 'yes_anyone_else',
+        pattern: utterances.yes,
         callback: (_, conversation) => {
           conversation.responses.repeat.spoken.push(repeatObject(conversation));
           conversation.gotoThread('who did you talk to');
@@ -185,7 +185,7 @@ function botThree(
         },
       },
       {
-        pattern: 'no_anyone_else',
+        pattern: utterances.no,
         callback: (_, conversation) => {
           conversation.responses.repeat.spoken.push(repeatObject(conversation));
           conversation.gotoThread('graceful ending');


### PR DESCRIPTION
Use already existing utterances.yes and utterances.no to allow for the bot
to work where the button doesn't such as in messenger lite.


Fixes #120 
